### PR TITLE
Command module dev

### DIFF
--- a/FSW/src/headers/comUtil.hpp
+++ b/FSW/src/headers/comUtil.hpp
@@ -16,21 +16,40 @@
 /* - - - - - - Declarations - - - - - - */
 
 // TODO: put this in config file
-static int commandQueueSize = 100;
 
 enum Command
 {
-    EnterSafemode, // enter safemode state
-    EnterStandby, // enter standby state
-    EnterDataCollection, // enter data collection mode
-    disableWDReset, // dsiable watchdog reset signal, forcing a restart
+    // Mode change
+    EnterSafeMode,              // enter safemode state
+    EnterStandbyMode,           // enter standby state
+    EnterSunsetMode,            // enter sunset data collection mode
+    EnterPreSunriseMode,        // enter watch-for-sunset mode
+    EnterSunriseMode,           // enter sunrise data collection mode
     
-    HeaterOn, // turn heater on
-    HeaterOff, // turn heater off
-    StartCommandSequence, // pause command execution
-    ExecuteAllCommands, // execute all commands in the queue
-}
+    // Memory handling
+    ForceSaveBuffer,            // save the buffer contents to flash immediately
+    EraseFlash,                 // wipe the flash modules
+
+    // System
+    DisableWDReset,             // disable watchdog reset signal, forcing a restart
+    HeaterOn,                   // turn heater on
+    HeaterOff,                  // turn heater off
+    StartCommandSequence,       // pause command execution
+    ExecuteAllCommands,         // execute all commands in the queue
+    
+    
+    DoNothing                  // this command does nothing. KEEP THIS LAST IN THE ENUM!
+};
 
 int commandHandling();
+
+class CommandQueue
+{
+    public:
+        int queue[COMMAND_QUEUE_SIZE];
+
+        CommandQueue();
+};
+
 
 #endif

--- a/FSW/src/headers/comUtil.hpp
+++ b/FSW/src/headers/comUtil.hpp
@@ -14,42 +14,37 @@
 
 
 /* - - - - - - Declarations - - - - - - */
+void commandHandling();
+int readCommand();
+void queueCommand(int command);
+bool checkMetaCommand(int command);
+void executeAllCommands();
+void clearCommandQueue();
+void executeCommand(int command);
 
-// TODO: put this in config file
-
-enum Command
+enum Command // all possible commands
 {
+    // commands are 1 indexed so that the default initializer can be used for the command queue
+
     // Mode change
-    EnterSafeMode,              // enter safemode state
-    EnterStandbyMode,           // enter standby state
-    EnterSunsetMode,            // enter sunset data collection mode
-    EnterPreSunriseMode,        // enter watch-for-sunset mode
-    EnterSunriseMode,           // enter sunrise data collection mode
+    ENTER_SAFE_MODE = 1,          // enter safemode state
+    ENTER_STANDBY_MODE,           // enter standby state
+    ENTER_SUNSET_MODE,            // enter sunset data collection mode
+    ENTER_PRE_SUNRISE_MODE,       // enter watch-for-sunset mode
+    ENTER_SUNRISE_MODE,           // enter sunrise data collection mode
     
-    // Memory handling
-    ForceSaveBuffer,            // save the buffer contents to flash immediately
-    EraseFlash,                 // wipe the flash modules
+    // Housekeeping
+    DISABLE_WD_RESET,             // disable watchdog reset signal, forcing a restart
+    HEATER_ON,                    // turn heater on, does not override housekeeping heater control
+    HEATER_OFF,                   // turn heater off, does not override housekeeping heater control
 
-    // System
-    DisableWDReset,             // disable watchdog reset signal, forcing a restart
-    HeaterOn,                   // turn heater on
-    HeaterOff,                  // turn heater off
-    StartCommandSequence,       // pause command execution
-    ExecuteAllCommands,         // execute all commands in the queue
+    // Command Handling
+    PAUSE_EXECUTE_COMMANDS,       // pause command execution
+    RESUME_EXECUTE_COMMANDS,      // resume command execution
+    CLEAR_COMMAND_QUEUE,          // clears all commands from queue
     
-    
-    DoNothing                  // this command does nothing. KEEP THIS LAST IN THE ENUM!
+    // End of list
+    DO_NOTHING                    // do nothing. KEEP THIS LAST IN THE ENUM, it is used for indexing.
 };
-
-int commandHandling();
-
-class CommandQueue
-{
-    public:
-        int queue[COMMAND_QUEUE_SIZE];
-
-        CommandQueue();
-};
-
 
 #endif

--- a/FSW/src/headers/comUtil.hpp
+++ b/FSW/src/headers/comUtil.hpp
@@ -1,0 +1,36 @@
+#ifndef COMUTIL_H
+#define COMUTIL_H 
+
+/* - - - - - - Includes - - - - - - */
+// C++ libraries
+
+// Other libraries
+#include <Arduino.h>
+
+// NS2 headers
+// (all of them)
+#include "config.hpp"
+#include "memUtil.hpp"
+
+
+/* - - - - - - Declarations - - - - - - */
+
+// TODO: put this in config file
+static int commandQueueSize = 100;
+
+enum Command
+{
+    EnterSafemode, // enter safemode state
+    EnterStandby, // enter standby state
+    EnterDataCollection, // enter data collection mode
+    disableWDReset, // dsiable watchdog reset signal, forcing a restart
+    
+    HeaterOn, // turn heater on
+    HeaterOff, // turn heater off
+    StartCommandSequence, // pause command execution
+    ExecuteAllCommands, // execute all commands in the queue
+}
+
+int commandHandling();
+
+#endif

--- a/FSW/src/headers/config.hpp
+++ b/FSW/src/headers/config.hpp
@@ -59,7 +59,7 @@ static Event saveBufferEvent;
 
 /* - - - - - - Command Handling Module - - - - - - */
 const int COMMAND_QUEUE_SIZE = 100;     // maximum number of commands the command queue can store.
-const int SERIAL_TIMEOUT_MSEC = 50;     // milliseconds, time to 
+const int SERIAL_TIMEOUT_MSEC = 50;     // milliseconds, maximum time to wait for serial input
 
 /* - - - - - - Fault Mitigation Module - - - - - - */
 const int WD_RESET_INTERVAL = 100;  // watchdog feeding interval, ms

--- a/FSW/src/headers/config.hpp
+++ b/FSW/src/headers/config.hpp
@@ -57,6 +57,10 @@ const int WINDOW_LENGTH_MSEC = WINDOW_LENGTH_SEC * 1000; // milliseconds, length
 static RecurringEvent dataProcessEvent(SAMPLE_PERIOD_MSEC); // assuming that duration arg is ms
 static Event saveBufferEvent;
 
+/* - - - - - - Command Handling Module - - - - - - */
+const int COMMAND_QUEUE_SIZE = 100;     // maximum number of commands the command queue can store.
+const int SERIAL_TIMEOUT_MSEC = 50;     // milliseconds, time to 
+
 /* - - - - - - Fault Mitigation Module - - - - - - */
 const int WD_RESET_INTERVAL = 100;  // watchdog feeding interval, ms
 const int WD_PULSE_DUR = 10;        // watchdog reset signal duration, MICROSECONDS!!!

--- a/FSW/src/util/comUtil.cpp
+++ b/FSW/src/util/comUtil.cpp
@@ -1,17 +1,16 @@
-/* hkUtil.cpp handles NS2 payload housekeeping
+/* comUtil.cpp handles NS2 payload commands
  * Usage:
- *  module functionality
- *      system state data collection
- *      temperature control
- * 
- *  function definitions
- *  put function declarations in memUtil.hpp
+ *  Reads incoming commands from serial, adds them to the command queue
+ *  and executes each command. 
+ *      
  * 
  * Modules encompassed:
- *  
+ *  Command Handling
  *
  * Additional files needed for compilation:
- *  none
+ *  config.hpp
+ *  comUtil.hpp
+ *  
  */
 
 /* - - - - - - Includes - - - - - - */

--- a/FSW/src/util/comUtil.cpp
+++ b/FSW/src/util/comUtil.cpp
@@ -22,7 +22,7 @@
 // NS2 headers
 #include "../headers/comUtil.hpp"
 
-int command[commandQueueSize];
+static CommandQueue commandQueue();
 
 
 /* - - - - - - Module Driver Functions - - - - - - */
@@ -40,28 +40,49 @@ int command[commandQueueSize];
  */
 void commandHandling()
 {
-    int newCommand = getCommand();
-    newCommand
+    int newCommandCode = getCommand();
+    
+    if (newCommandCode != -1) // if the new command is valid, add it to the queue
+    {
+        queueCommand(newCommandCode);
+    }
+
 }
 
 
-
-byte getCommand();
+int getCommand();
 {
     // read Serial
     if (Serial.available() > 0) // check if there is serial input
     {
-        int serialInput = Serial.parseInt();
-        return serialInput;
+        int serialInput = Serial.parseInt(); // read the command
+        if ((serialInput <= static_cast<int>(Command::DoNothing)) && (serialInput >= 0)) // check if command is valid
+        {
+            Serial.println("Command Recieved.")
+            return serialInput;
+        }
+        else
+        {
+            Serial.println("Invalid command recieved.");
+            Serial.println("(Command Handling)");
+        }
     }
-    return 0; // no command
+    return -1; // no command
 
 }
 
-void parseCommand(byte command)
+void queueCommand(int commandCode)
 {
-    switch newCommand
-    {
 
+}
+
+void executeCommand(int commandCode)
+{
+    switch (commandCode)
+    {
+        case EnterSafeMode:
+        {
+            
+        }
     }
 }

--- a/FSW/src/util/comUtil.cpp
+++ b/FSW/src/util/comUtil.cpp
@@ -28,8 +28,6 @@ int commandQueue[COMMAND_QUEUE_SIZE] = {};  // initializes as all zeros
 static int queueIndex = 0;                  // next available index of command queue
 static bool isPaused = false;               // indicates if command execution is paused
 
-// TODO: set Serial.setTimeout() in config.hpp
-
 /* - - - - - - Module Driver Functions - - - - - - */
 
 /* - - - - - - commandHandling - - - - - - *
@@ -83,7 +81,11 @@ int readCommand()
         }
         else
         {
-            Serial.println("Invalid command recieved.");
+            // print warning, indicating the invalid command and the range of valid commands
+            Serial.print("Invalid command recieved: ");
+            Serial.println(serialInput);
+            Serial.print("Valid commands are between 1 and ");
+            Serial.println(static_cast<int>(Command::DO_NOTHING));
             Serial.println("(Command Handling)");
         }
     }
@@ -224,7 +226,6 @@ void executeCommand(int command)
             // TODO: call corresponding function in timing module
             break;
         
-        
         // Housekeeping
         case DISABLE_WD_RESET: 
             // TODO: change WD timer value to >1.2 sec by calling setDuration()
@@ -238,7 +239,6 @@ void executeCommand(int command)
             // TODO: call corresponding function in houskeeping module
             break;
         
-
         // Command Handling
         case PAUSE_EXECUTE_COMMANDS: 
             isPaused = true;

--- a/FSW/src/util/comUtil.cpp
+++ b/FSW/src/util/comUtil.cpp
@@ -20,45 +20,66 @@
 // Other libraries
 
 // NS2 headers
+#include "../headers/config.hpp"
 #include "../headers/comUtil.hpp"
 
-static CommandQueue commandQueue();
 
+/* Module Variable Definitions */
+int commandQueue[COMMAND_QUEUE_SIZE] = {};  // initializes as all zeros
+static int queueIndex = 0;                  // next available index of command queue
+static bool isPaused = false;               // indicates if command execution is paused
+
+// TODO: set Serial.setTimeout() in config.hpp
 
 /* - - - - - - Module Driver Functions - - - - - - */
 
 /* - - - - - - commandHandling - - - - - - *
  * Usage:
- *  looks for and reads incoming commands, adds them to the command queue, and executes
+ *  looks for and reads incoming commands via serial, adds them to the command queue, and executes
  *  each command in the queue
  * 
  * Inputs:
  *  none
- *  
+ * 
  * Outputs:
  *  None
  */
 void commandHandling()
 {
-    int newCommandCode = getCommand();
-    
-    if (newCommandCode != -1) // if the new command is valid, add it to the queue
+    int newCommand = readCommand(); // read command from serial
+    if (checkMetaCommand(newCommand)) // if new command is a meta command, execute it immediately
     {
-        queueCommand(newCommandCode);
+        executeCommand(newCommand);
     }
-
+    else if (newCommand != -1) // if the new command is valid, add it to the queue
+    {
+        queueCommand(newCommand);
+    }
+    executeAllCommands(); // execute all commands in the queue
 }
 
+/* - - - - - - Helper Functions - - - - - - */
 
-int getCommand();
+/* - - - - - - readCommand - - - - - - *
+ * Usage:
+ *  Reads serial input for an incoming command, checks if it has recieved a valid command,
+ *  and returns the new command
+ * 
+ * Inputs:
+ *  none
+ * 
+ * Outputs:
+ *  a single valid command code, or -1 if no valid code is recieved
+ */
+int readCommand()
 {
     // read Serial
     if (Serial.available() > 0) // check if there is serial input
     {
         int serialInput = Serial.parseInt(); // read the command
-        if ((serialInput <= static_cast<int>(Command::DoNothing)) && (serialInput >= 0)) // check if command is valid
+        if ((serialInput <= static_cast<int>(Command::DO_NOTHING)) && (serialInput > 0)) // check if command is valid
         {
-            Serial.println("Command Recieved.")
+            //Serial.println("Command Recieved."); // for debugging
             return serialInput;
         }
         else
@@ -68,21 +89,181 @@ int getCommand();
         }
     }
     return -1; // no command
-
 }
 
-void queueCommand(int commandCode)
+/* - - - - - - queueCommand - - - - - - *
+ * Usage:
+ *  Adds command to the next availiable spot in the command queue.
+ *  New commands are not added if the queue is full.
+ * 
+ * Inputs:
+ *  command - a single command code
+ * 
+ * Outputs:
+ *  None
+ */
+void queueCommand(int command)
 {
-
-}
-
-void executeCommand(int commandCode)
-{
-    switch (commandCode)
+    if (queueIndex < COMMAND_QUEUE_SIZE) // if end of queue has not been reached, add command to queue 
     {
-        case EnterSafeMode:
+        commandQueue[queueIndex] = command;
+        queueIndex++;
+    }
+    else
+    {
+        Serial.println("Command queue full.");
+        Serial.println("(Command Handling)");
+    }
+}
+
+/* - - - - - - checkMetaCommand - - - - - - *
+ * Usage:
+ *  Checks if input command is a meta command.
+ *  Meta commands are executed immediately even if the queue is paused
+ * 
+ * Inputs:
+ *  command - a single command code
+ * 
+ * Outputs:
+ *  True if meta command detected
+ *  False if no meta command detected
+ */
+bool checkMetaCommand(int command)
+{
+    command = static_cast<Command>(command);
+    switch (command)
+    {
+        case PAUSE_EXECUTE_COMMANDS: 
+            break;
+        case RESUME_EXECUTE_COMMANDS:
+            break;
+        case CLEAR_COMMAND_QUEUE:
+            break;
+        default:
+            return false; // no meta command detected
+            break;
+    }
+    return true;
+}
+
+/* - - - - - - executeAllCommands - - - - - - *
+ * Usage:
+ *  Executes every command in the command queue, starting from index 0 and up to the current index
+ * 
+ * Inputs:
+ *  None 
+ * 
+ * Outputs:
+ *  None
+ */
+void executeAllCommands()
+{
+    if (!isPaused) // if command execution is not paused
+    {
+        for (int i = 0; i < queueIndex; i++) // execute each command in the queue
         {
-            
+            executeCommand(commandQueue[i]);
         }
+        clearCommandQueue();
+    }
+}
+
+/* - - - - - - clearCommandQueue - - - - - - *
+ * Usage:
+ *  Sets all elements in command queue to 0
+ *  resets queue index to 0.
+ * 
+ * Inputs:
+ *  None 
+ * 
+ * Outputs:
+ *  None
+ */
+void clearCommandQueue()
+{
+    for (int i = 0; i < COMMAND_QUEUE_SIZE; i++) // execute each command in the queue
+        {
+            commandQueue[i] = 0;
+        }
+        queueIndex = 0; // reset queue index
+}
+
+/* - - - - - - executeCommand - - - - - - *
+ * Usage:
+ *  executes a single command by checking it against the Command enum
+ * 
+ * Inputs:
+ *  command - a single command code
+ * 
+ * Outputs:
+ *  None
+ */
+void executeCommand(int command)
+{
+    // When adding new commands, make sure to include any relevant headers!
+    command = static_cast<Command>(command); // cast command as Command enum
+    switch (command)
+    {
+        // Mode change
+        case ENTER_SAFE_MODE: 
+            // TODO: call corresponding function in timing module
+            break;
+        
+        case ENTER_STANDBY_MODE: 
+            // TODO: call corresponding function in timing module
+            break;
+        
+        case ENTER_SUNSET_MODE: 
+            // TODO: call corresponding function in timing module
+            break;
+        
+        case ENTER_PRE_SUNRISE_MODE: 
+            // TODO: call corresponding function in timing module
+            break;
+        
+        case ENTER_SUNRISE_MODE: 
+            // TODO: call corresponding function in timing module
+            break;
+        
+        
+        // Housekeeping
+        case DISABLE_WD_RESET: 
+            // TODO: change WD timer value to >1.2 sec by calling setDuration()
+            break;
+        
+        case HEATER_ON: 
+            // TODO: call corresponding function in housekeeping module
+            break;
+        
+        case HEATER_OFF: 
+            // TODO: call corresponding function in houskeeping module
+            break;
+        
+
+        // Command Handling
+        case PAUSE_EXECUTE_COMMANDS: 
+            isPaused = true;
+            Serial.println("Command execution paused.");
+            break;
+        
+        case RESUME_EXECUTE_COMMANDS: 
+            isPaused = false;
+            Serial.println("Command execution resumed.");
+            break;
+        
+        case CLEAR_COMMAND_QUEUE: 
+            clearCommandQueue();
+            Serial.println("Command queue cleared.");
+            break;
+
+        // End of list
+        case DO_NOTHING: 
+            Serial.println("Doing nothing.");
+            break;
+        
+        default: 
+            Serial.println("Code in command queue has no matching command (this should not happen).");
+            Serial.println("(Command Handling)");
+            break;
     }
 }

--- a/FSW/src/util/comUtil.cpp
+++ b/FSW/src/util/comUtil.cpp
@@ -1,0 +1,67 @@
+/* hkUtil.cpp handles NS2 payload housekeeping
+ * Usage:
+ *  module functionality
+ *      system state data collection
+ *      temperature control
+ * 
+ *  function definitions
+ *  put function declarations in memUtil.hpp
+ * 
+ * Modules encompassed:
+ *  
+ *
+ * Additional files needed for compilation:
+ *  none
+ */
+
+/* - - - - - - Includes - - - - - - */
+// C++ libraries
+
+// Other libraries
+
+// NS2 headers
+#include "../headers/comUtil.hpp"
+
+int command[commandQueueSize];
+
+
+/* - - - - - - Module Driver Functions - - - - - - */
+
+/* - - - - - - commandHandling - - - - - - *
+ * Usage:
+ *  looks for and reads incoming commands, adds them to the command queue, and executes
+ *  each command in the queue
+ * 
+ * Inputs:
+ *  none
+ *  
+ * Outputs:
+ *  None
+ */
+void commandHandling()
+{
+    int newCommand = getCommand();
+    newCommand
+}
+
+
+
+byte getCommand();
+{
+    // read Serial
+    if (Serial.available() > 0) // check if there is serial input
+    {
+        int serialInput = Serial.parseInt();
+        return serialInput;
+    }
+    return 0; // no command
+
+}
+
+void parseCommand(byte command)
+{
+    switch newCommand
+    {
+
+    }
+}


### PR DESCRIPTION
Command handling base functionality. Everything is tested on the teensy.
Added command queue size and serial timeout variables in config.hpp. 

New commands just need an entry in the Command enum (in comUtil.hpp) and an implementation in the huge switch statement (in comUtil.cpp). Commands can be easily added while keeping related commands numerically adjacent. The enum handles all the indexing for us.

Commands that affect the command handling module itself are dubbed meta-commands, they are not added to the queue, but are instead executed immediately, this way meta-commands can manipulate the behavior of the queue without affecting themselves.
