### PR TITLE
timing module cleanup and timestamp append in memUtil

### DIFF
--- a/FSW/main.cpp
+++ b/FSW/main.cpp
@@ -35,9 +35,13 @@ int main()
     // TODO: Change main loop to account for critical exit conditions
     while(true) // run main loop forever
     {
+        // execute commands  
+        commandHandling();
+
         // test multiple file structure by calling functions from memUtil.cpp
-        scienceMemoryHandling();
-        break;
+        if (scienceMode.get() != SAFE_MODE){
+            scienceMemoryHandling();
+        }
     }
 
     return 0;

--- a/FSW/main.cpp
+++ b/FSW/main.cpp
@@ -66,7 +66,7 @@ int main()
         return -1;
     }
     
-    while(true) // run main loop forever
+    while(true) // run main loop until exit command
     {
         // execute commands  
         commandHandling();

--- a/FSW/main.cpp
+++ b/FSW/main.cpp
@@ -14,9 +14,31 @@
 // Other libraries
 
 // NS2 headers
+#include "src/headers/config.hpp"
+#include "src/headers/comUtil.hpp"
+#include "src/headers/eventUtil.hpp"
+#include "src/headers/timingClass.hpp"
+#include "src/headers/timing.hpp"
 #include "src/headers/memUtil.hpp"
 
 /* - - - - - - Functions - - - - - - */
+
+/* - - - - - - init - - - - - - *
+ * Usage:
+ *  initializes NanoSAM II FSW
+ * 
+ * Inputs:
+ *  none
+ *  
+ * Outputs:
+ *  initStatus - flag (true if initialization was successful)
+ */
+bool init(){
+    scienceMode.setPointingAtSun(true);
+    scienceMode.setMode(SAFE_MODE); // this is done in the class constructor so we may not need it
+
+    return true;
+}
 
 /* - - - - - - main - - - - - - *
  * Usage:
@@ -31,6 +53,10 @@
 int main()
 {
     //carry out initializations
+    if (!init()){
+        Serial.println("Initialization failed, exiting main loop");
+        return -1;
+    }
     
     // TODO: Change main loop to account for critical exit conditions
     while(true) // run main loop forever
@@ -39,11 +65,10 @@ int main()
         commandHandling();
 
         // test multiple file structure by calling functions from memUtil.cpp
-        if (scienceMode.get() != SAFE_MODE){
+        if (scienceMode.getMode() != SAFE_MODE){
             scienceMemoryHandling();
         }
     }
 
     return 0;
 }
-

--- a/FSW/main.cpp
+++ b/FSW/main.cpp
@@ -34,6 +34,8 @@
  *  initStatus - flag (true if initialization was successful)
  */
 bool init(){
+    Serial.print("Initializing NanoSAM II FSW... ");
+
     scienceMode.setPointingAtSun(true);
     scienceMode.setMode(SAFE_MODE); // this is done in the class constructor so we may not need it
 
@@ -41,6 +43,8 @@ bool init(){
     //    it here with a value that is a function of existing vars in config.hpp
     scienceMode.sweepChangeLockout.setDuration(ADCS_SWEEP_CHANGE_DURATION);
 
+
+    Serial.println("Complete");
     return true;
 }
 
@@ -62,7 +66,6 @@ int main()
         return -1;
     }
     
-    // TODO: Change main loop to account for critical exit conditions
     while(true) // run main loop forever
     {
         // execute commands  
@@ -71,6 +74,11 @@ int main()
         // test multiple file structure by calling functions from memUtil.cpp
         if (scienceMode.getMode() != SAFE_MODE){
             scienceMemoryHandling();
+        }
+
+        if (scienceMode.exitMainLoopEvent.checkInvoked()){
+            Serial.println("Exiting main loop");
+            break;
         }
     }
 

--- a/FSW/main.cpp
+++ b/FSW/main.cpp
@@ -37,6 +37,10 @@ bool init(){
     scienceMode.setPointingAtSun(true);
     scienceMode.setMode(SAFE_MODE); // this is done in the class constructor so we may not need it
 
+    // lockout duration has to be initialized with a bad value for compilation, overwrite
+    //    it here with a value that is a function of existing vars in config.hpp
+    scienceMode.sweepChangeLockout.setDuration(ADCS_SWEEP_CHANGE_DURATION);
+
     return true;
 }
 

--- a/FSW/src/headers/comUtil.hpp
+++ b/FSW/src/headers/comUtil.hpp
@@ -47,6 +47,9 @@ enum Command // all possible commands
     ADCS_POINTING_AT_SUN_T,       // sets pointing at sun flag to true
     ADCS_POINTING_AT_SUN_F,       // sets pointing at sun flag to false
 
+    // Main Loop Commands
+    EXIT_MAIN_LOOP,
+
     // End of list
     DO_NOTHING                    // do nothing. KEEP THIS LAST IN THE ENUM, it is used for indexing.
 };

--- a/FSW/src/headers/comUtil.hpp
+++ b/FSW/src/headers/comUtil.hpp
@@ -43,6 +43,10 @@ enum Command // all possible commands
     RESUME_EXECUTE_COMMANDS,      // resume command execution
     CLEAR_COMMAND_QUEUE,          // clears all commands from queue
     
+    // ADCS
+    ADCS_POINTING_AT_SUN_T,       // sets pointing at sun flag to true
+    ADCS_POINTING_AT_SUN_F,       // sets pointing at sun flag to false
+
     // End of list
     DO_NOTHING                    // do nothing. KEEP THIS LAST IN THE ENUM, it is used for indexing.
 };

--- a/FSW/src/headers/config.hpp
+++ b/FSW/src/headers/config.hpp
@@ -11,8 +11,8 @@
  */
 
 // NS2 Headers
-#include "timingClass.hpp"
 #include "eventUtil.hpp"
+#include "timingClass.hpp"
 
 /* = = = = = = = = = = = = = = = = = = = = = = = = = =
  * = = = = = = Configuration Declarations  = = = = = = 
@@ -69,11 +69,6 @@ static Event saveBufferEvent;
 static TimedEvent sunriseTimerEvent(WINDOW_LENGTH_MSEC);
 static TimedEvent sweepTimeoutEvent(SWEEP_TIMEOUT_MSEC);
 
-// FUTURE TEAMS: this event is invoked when the ADCS should switch its sweep direction
-//   so link your ADCS module with this event to tell it when to switch direction 
-//      look at checkSweepChange() in timing.cpp for more info
-static Event sweepDirectionChangeEvent; 
-
 /* - - - - - - Command Handling Module - - - - - - */
 const int COMMAND_QUEUE_SIZE = 100;     // maximum number of commands the command queue can store.
 const int SERIAL_TIMEOUT_MSEC = 50;     // milliseconds, maximum time to wait for serial input
@@ -86,6 +81,7 @@ const int WD_PULSE_DUR = 10;        // watchdog reset signal duration, MICROSECO
 const float SUN_THRESH_VOLTAGE = (ADC_MAX_VOLTAGE - ADC_MIN_VOLTAGE) / 4; // value signifying we are pointing at sun
 const int SMOOTH_IDX_COUNT = 5; // number of indices to use in smoothing the voltage buffer for mode change comparisons
 const int ADCS_SWEEP_IDX_OFFSET = SMOOTH_IDX_COUNT; // number of indices to traverse backwards in buffer when checking ADCS sweep direction 
+const int ADCS_SWEEP_CHANGE_DURATION = 2 * SMOOTH_IDX_COUNT * SAMPLE_PERIOD_MSEC; // duration to prevent ADCS sweep direction change
 
 // timing science mode object declaration
 static ScienceMode scienceMode;

--- a/FSW/src/headers/config.hpp
+++ b/FSW/src/headers/config.hpp
@@ -52,11 +52,11 @@ const float ADC_MAX_VOLTAGE = 3.3;  // Volts, upper end of ADC voltage range
 const float ADC_MIN_VOLTAGE = 0.0;  // Volts, lower end of ADC voltage range
 
 // TODO: Update this with size of actual timestamp once it is known
-const int TIMESTAMP_SIZE = 1;   // array indices needed to store timestamp
+const int TIMESTAMP_SIZE = sizeof(unsigned long);   // bytes needed to store timestamp
 
 // set number of measurements to store in science data buffer
-const int BUFFERSIZE = SAMPLING_RATE * WINDOW_LENGTH_SEC; // indices
-const int FILESIZE = BUFFERSIZE + TIMESTAMP_SIZE;
+const int BUFFERSIZE = SAMPLING_RATE * WINDOW_LENGTH_SEC; // indices in array
+const int FILESIZE = (BUFFERSIZE * sizeof(float)) + TIMESTAMP_SIZE; // bytes in file
 
 // timing constants
 const unsigned long SAMPLE_PERIOD_MSEC = 1000 / (unsigned long)SAMPLING_RATE; // millisec, time between samples  

--- a/FSW/src/headers/config.hpp
+++ b/FSW/src/headers/config.hpp
@@ -81,7 +81,7 @@ const int WD_PULSE_DUR = 10;        // watchdog reset signal duration, MICROSECO
 const float SUN_THRESH_VOLTAGE = (ADC_MAX_VOLTAGE - ADC_MIN_VOLTAGE) / 4; // value signifying we are pointing at sun
 const int SMOOTH_IDX_COUNT = 5; // number of indices to use in smoothing the voltage buffer for mode change comparisons
 const int ADCS_SWEEP_IDX_OFFSET = SMOOTH_IDX_COUNT; // number of indices to traverse backwards in buffer when checking ADCS sweep direction 
-const int ADCS_SWEEP_CHANGE_DURATION = 2 * SMOOTH_IDX_COUNT * SAMPLE_PERIOD_MSEC; // duration to prevent ADCS sweep direction change
+const int ADCS_SWEEP_CHANGE_DURATION = 2 * SMOOTH_IDX_COUNT * SAMPLE_PERIOD_MSEC; // millisec, duration to prevent ADCS sweep direction change
 
 // timing science mode object declaration
 static ScienceMode scienceMode;

--- a/FSW/src/headers/eventUtil.hpp
+++ b/FSW/src/headers/eventUtil.hpp
@@ -36,6 +36,7 @@ class TimedEvent : public Event
 
     public:
         TimedEvent(unsigned long newDuration);
+        TimedEvent(); // overloaded constructor to set default duration
         void setDuration(unsigned long newDuration);
         bool checkInvoked();
         void start();

--- a/FSW/src/headers/memUtil.hpp
+++ b/FSW/src/headers/memUtil.hpp
@@ -8,6 +8,7 @@
 // Other libraries
 #include <SerialFlash.h> // for file I/O to flash modules
 #include <SPI.h> // will probably use this shortly, but it is not in use yet
+#include <TimeLib.h>
 
 // NS2 headers
 #include "config.hpp"
@@ -17,5 +18,6 @@ float dataProcessing();
 void scienceMemoryHandling();
 void updateBuffer(float sample, int &index);
 bool saveBuffer(int &index);
+unsigned long calcTimestamp(); // currently outputs relative timestamp instead of absolute timestamp
 
 #endif

--- a/FSW/src/headers/timing.hpp
+++ b/FSW/src/headers/timing.hpp
@@ -36,5 +36,4 @@ void updatePayloadMode(float buffer[BUFFERSIZE], int bufIdx);
 float voltageRunningMean(float buffer[BUFFERSIZE], int bufIdx);
 void checkSweepChange(float buffer[BUFFERSIZE], int bufIdx);
 int wrapBufferIdx(int idx);
-// TODO recoverPayloadMode();
 #endif

--- a/FSW/src/headers/timing.hpp
+++ b/FSW/src/headers/timing.hpp
@@ -33,7 +33,7 @@ enum Mode // all payload science modes
 
 /* - - - - - - Declarations - - - - - - */
 void updatePayloadMode(float buffer[BUFFERSIZE], int bufIdx);
-float smoothBuffer(float buffer[BUFFERSIZE], int bufIdx);
+float voltageRunningMean(float buffer[BUFFERSIZE], int bufIdx);
 void checkSweepChange(float buffer[BUFFERSIZE], int bufIdx);
 int wrapBufferIdx(int idx);
 // TODO recoverPayloadMode();

--- a/FSW/src/headers/timingClass.hpp
+++ b/FSW/src/headers/timingClass.hpp
@@ -13,12 +13,24 @@ class ScienceMode
 {
     protected:
         int mode; // according to mode enum
-        // could add more states such as ADCS ready, sweep direction, etc.
+        bool adcsPointingAtSun; // flag from ADCS signaling optic is pointing at sun
 
     public:
         ScienceMode();
-        int get();
-        void set(int newMode);
+        int getMode();
+        void setMode(int newMode);
+
+        // setter and getter for adcsPointingAtSun
+        bool getPointingAtSun();
+        void setPointingAtSun(bool newState);
+        void sweepChange();
+
+        // FUTURE TEAMS: this event is invoked when the ADCS should switch its sweep direction
+        //   so link your ADCS module with this event to tell it when to switch direction 
+        //      look at checkSweepChange() in timing.cpp for more info
+        Event sweepChangeEvent();
+        // lockout to prevent sweep change while ADCS is reversing direction
+        TimedEvent sweepChangeLockout(unsigned long ADCS_SWEEP_CHANGE_DURATION);
 };
 
 #endif

--- a/FSW/src/headers/timingClass.hpp
+++ b/FSW/src/headers/timingClass.hpp
@@ -14,7 +14,7 @@ class ScienceMode
     protected:
         int mode; // according to mode enum
         bool adcsPointingAtSun; // flag from ADCS signaling optic is pointing at sun
-
+        
     public:
         ScienceMode();
         int getMode();
@@ -24,6 +24,9 @@ class ScienceMode
         bool getPointingAtSun();
         void setPointingAtSun(bool newState);
         void sweepChange();
+
+        // event for exiting main loop
+        Event exitMainLoopEvent;
 
         // FUTURE TEAMS: this event is invoked when the ADCS should switch its sweep direction
         //   so link your ADCS module with this event to tell it when to switch direction 

--- a/FSW/src/headers/timingClass.hpp
+++ b/FSW/src/headers/timingClass.hpp
@@ -28,9 +28,11 @@ class ScienceMode
         // FUTURE TEAMS: this event is invoked when the ADCS should switch its sweep direction
         //   so link your ADCS module with this event to tell it when to switch direction 
         //      look at checkSweepChange() in timing.cpp for more info
-        Event sweepChangeEvent();
+        Event sweepChangeEvent;
+        
         // lockout to prevent sweep change while ADCS is reversing direction
-        TimedEvent sweepChangeLockout(unsigned long ADCS_SWEEP_CHANGE_DURATION);
+        // (has placeholder duration for compilation, this is set properly during initialization)
+        TimedEvent sweepChangeLockout; 
 };
 
 #endif

--- a/FSW/src/util/comUtil.cpp
+++ b/FSW/src/util/comUtil.cpp
@@ -271,6 +271,11 @@ void executeCommand(int command)
             Serial.println("Command Recieved - ADCS_POINTING_AT_SUN set to false.");
             break;
 
+        case EXIT_MAIN_LOOP:
+            scienceMode.exitMainLoopEvent.invoke();
+            Serial.println("Command Recieved - Exiting main loop at next opportunity.");
+            break;
+
         // End of list
         case DO_NOTHING: 
             Serial.println("Doing nothing.");

--- a/FSW/src/util/comUtil.cpp
+++ b/FSW/src/util/comUtil.cpp
@@ -207,27 +207,28 @@ void executeCommand(int command)
     {
         // Mode change
         case ENTER_SAFE_MODE: 
-            scienceMode.set(SAFE_MODE);
+            scienceMode.setMode(SAFE_MODE);
             Serial.println("Command Recieved - Entering Safe Mode. This mode must be manually exited.");
             break;
         
         case ENTER_STANDBY_MODE: 
-            scienceMode.set(STANDBY_MODE);
+            scienceMode.setMode(STANDBY_MODE);
             Serial.println("Command Recieved - Entering Standby Mode. This mode must be manually exited.");
             break;
         
         case ENTER_SUNSET_MODE: 
-            scienceMode.set(SUNSET_MODE);
+            scienceMode.setMode(SUNSET_MODE);
             Serial.println("Command Recieved - Entering Sunset Mode.");
             break;
         
         case ENTER_PRE_SUNRISE_MODE: 
-            scienceMode.set(PRE_SUNRISE_MODE);
+            scienceMode.setMode(PRE_SUNRISE_MODE);
             Serial.println("Command Recieved - Entering Pre-Sunrise Mode.");
             break;
         
         case ENTER_SUNRISE_MODE: 
-            scienceMode.set(SUNRISE_MODE);
+            sunriseTimerEvent.start(); // sunrise mode will never end w/o this call
+            scienceMode.setMode(SUNRISE_MODE);
             Serial.println("Command Recieved - Entering Sunrise Mode.");
             break;
         
@@ -258,6 +259,16 @@ void executeCommand(int command)
         case CLEAR_COMMAND_QUEUE: 
             clearCommandQueue();
             Serial.println("Command queue cleared.");
+            break;
+
+        case ADCS_POINTING_AT_SUN_T:
+            scienceMode.setPointingAtSun(true);
+            Serial.println("Command Recieved - ADCS_POINTING_AT_SUN set to true.");
+            break;
+
+        case ADCS_POINTING_AT_SUN_F:
+            scienceMode.setPointingAtSun(false);
+            Serial.println("Command Recieved - ADCS_POINTING_AT_SUN set to false.");
             break;
 
         // End of list

--- a/FSW/src/util/eventUtil.cpp
+++ b/FSW/src/util/eventUtil.cpp
@@ -52,6 +52,15 @@ TimedEvent::TimedEvent(unsigned long newDuration) // constructor
     isInvoked = true;  // A timed event will not invoke itself unless start() is first called
 }
 
+TimedEvent::TimedEvent() // overloaded constructor to set default duration
+{
+    unsigned long defaultDuration = 1000; // milliseconds
+    duration = defaultDuration; 
+    currentMillis = millis();
+    nextInvokeMillis = 0;
+    isInvoked = true;  // A timed event will not invoke itself unless start() is first called
+}
+
 void TimedEvent::setDuration(unsigned long newDuration) // set new duration
 {
     duration = newDuration;

--- a/FSW/src/util/memUtil.cpp
+++ b/FSW/src/util/memUtil.cpp
@@ -70,7 +70,7 @@ float dataProcessing()
      */
 
     // convert from Bin number to voltage, assuming board voltage does not fluctuate
-    voltage = photodiode16 / ADC_BINS * (ADC_MAX_VOLTAGE - ADC_MIN_VOLTAGE);
+    voltage = (float)photodiode16 / ADC_BINS * (ADC_MAX_VOLTAGE - ADC_MIN_VOLTAGE);
 
     return voltage;
 }

--- a/FSW/src/util/memUtil.cpp
+++ b/FSW/src/util/memUtil.cpp
@@ -59,7 +59,7 @@ float dataProcessing()
     SPI.endTransaction();
 
     /* NOTE TO FUTURE TEAMS:
-     *      Append pointing data to the voltage here
+     *      Append ADCS attitude (direction payload is pointing) to the voltage here
      *      pointing data it essential for profiling the aerosol contents
      *      of the atmosphere, if we do not have pointing data associated with
      *      the voltage measurement we do not actually achieve any science
@@ -99,7 +99,7 @@ void scienceMemoryHandling()
         Serial.print("Photodiode Voltage: ");
         Serial.print(photodiodeVoltage);
         Serial.print(" - Payload Mode ");
-        Serial.println(scienceMode.get());
+        Serial.println(scienceMode.getMode());
     }
 
     if (saveBufferEvent.checkInvoked()){

--- a/FSW/src/util/memUtil.cpp
+++ b/FSW/src/util/memUtil.cpp
@@ -183,7 +183,7 @@ bool saveBuffer(int &index){
     int fileIdx = 0; // iterator for loop checking file existence
     bool fileFlag = true;
     char filename[] = "scienceFile0.csv";   // null-terminated char array
-    int fileIdxOffset = 11;                 // index of file number
+    int fileIdxOffset = 11;                 // index of file number in char array
 
     while (fileFlag){
         if (fileIdx < MAXFILES){ // prevent infinite loop
@@ -214,10 +214,49 @@ bool saveBuffer(int &index){
     // TODO: may need to seek position to end of file before writing again
     //file.seek(BUFFERSIZE);  
 
-    //TODO: decide on timestamp format and append it to file
-    //file.write(timestamp);
+    // compute and write timestamp
+    unsigned long timestamp = calcTimestamp();
+    file.write(&timestamp, sizeof(timestamp));
 
     index = 0; // reset index to start of array since we have saved the buffer
 
     return status; // return whether or not file was successfully created
+}
+
+/* - - - - - - calcTimestamp - - - - - - *
+ * Belongs to Science Memory Handling Module
+ *  
+ * Usage:
+ *  computes the relative time between teensy startup and when this file is saved
+ *  returns relative time be appended to the end of the file   
+ *  NOTE: in the file, only the timestamp of the final data point will be 
+ *        available. Use GSW and the sampling rate of FSW to backsolve for the 
+ *        timestamp of all preceding data points
+ * 
+ * FOR FUTURE TEAMS:
+ * this year's time is relative since we do not have a bus clock signal
+ *   however, it may be desirable to downlink the times in UTC or another standardized
+ *   time so that you do not have to keep track of the time that the teensy powered on
+ * By piping in a clock signal from the bus, you could potentially use the 
+ *  teensy time library to append timestamp
+ *  https://www.pjrc.com/teensy/td_libs_Time.html
+ *  might be useful to convert timestamp to ISO 8601 timekeeping standard for storing to file
+ *       ([YYYY]-[MM]-[DD]T[hh]:[mm]:[ss].[sss] where [sss] is subseconds)
+ * 
+ * Inputs:
+ *  none
+ *  
+ * Outputs:
+ *  relative timestamp
+ */
+unsigned long calcTimestamp(){
+    unsigned long currentTimeRelative = millis(); // milliseconds    
+
+    // FUTURE TEAMS: offset this relative time by the known time from the bus so that 
+    // a UTC (or some other standard) time is downlinked instead of a relative time
+
+    // for now we just return relative time
+    unsigned long timestamp = currentTimeRelative; 
+
+    return timestamp;
 }

--- a/FSW/src/util/timing.cpp
+++ b/FSW/src/util/timing.cpp
@@ -244,6 +244,11 @@ void checkSweepChange(float buffer[], int bufIdx){
 /* - - - - - - TODO: recoverPayloadMode - - - - - - *
  * Usage:
  *  Called in init routine to determine the payload mode after an unexpected shutdown
+ *  would be useful to implement in the future if the payload mode list becomes more complicated
+ *  but for now the payload mode is just initialized as STANDBY_MODE in the constructor
+ *  which is sufficient for testing at this stage
+ *  If an unexpected shutdown were to happen at this point, returning to STANDBY_MODE is 
+ *  always the proper response, as this will result in a maximum of two lost data windows
  * 
  * Inputs:
  * 

--- a/FSW/src/util/timing.cpp
+++ b/FSW/src/util/timing.cpp
@@ -86,7 +86,7 @@ void updatePayloadMode(float buffer[], int bufIdx){
         if (scienceMode.getPointingAtSun()){
 
             // smooth data to avoid a single noisy value prematurely ending a window
-            float pdVoltageSmooth = smoothBuffer(buffer, bufIdx); //photodiode voltage
+            float pdVoltageSmooth = voltageRunningMean(buffer, bufIdx); //photodiode voltage
             
             switch (currentMode) 
             {
@@ -155,7 +155,7 @@ void updatePayloadMode(float buffer[], int bufIdx){
     }
 }
 
-/* - - - - - - smoothBuffer - - - - - - *
+/* - - - - - - voltageRunningMean - - - - - - *
  * Usage:
  *  Apply basic smoothing to a configurable number of the most recent buffer entries
  *  Avoids a single noisy measurement prematurely ending a window
@@ -168,7 +168,7 @@ void updatePayloadMode(float buffer[], int bufIdx){
  * Outputs:
  *  smoothVoltage - average of the previous SMOOTH_IDX_COUNT indices of buffer
  */
-float smoothBuffer(float buffer[], int bufIdx){
+float voltageRunningMean(float buffer[], int bufIdx){
     float smoothVoltage = 0;
     int i, idx;
     for (i = bufIdx; i > bufIdx - SMOOTH_IDX_COUNT; i--){ // decrement to move backwards in time
@@ -229,10 +229,10 @@ int wrapBufferIdx(int idx){
  */
 void checkSweepChange(float buffer[], int bufIdx){
     // get the most recent smoothed photodiode voltage
-    float pdNew = smoothBuffer(buffer, bufIdx);
+    float pdNew = voltageRunningMean(buffer, bufIdx);
 
     // subtract the proper number of indices to get the next most recent photodiode voltage
-    float pdOld = smoothBuffer(buffer, wrapBufferIdx(bufIdx - ADCS_SWEEP_IDX_OFFSET));
+    float pdOld = voltageRunningMean(buffer, wrapBufferIdx(bufIdx - ADCS_SWEEP_IDX_OFFSET));
 
     // change the sweep direction if the voltage crossed the threshold
     //  requires optic to have recently dropped below the voltage threshold 

--- a/FSW/src/util/timing.cpp
+++ b/FSW/src/util/timing.cpp
@@ -211,8 +211,8 @@ int wrapBufferIdx(int idx){
     Serial.println(" tries.");
     Serial.println("Defaulting to an index of 0 (Timing module)");
     
-    // TODO: Should this return -1 instead to throw an error?
-    return 0;
+    // Return -1 to throw an error since something has gone very wrong if we get here
+    return -1;
 }
 
 /* - - - - - - checkSweepChange - - - - - - *

--- a/FSW/src/util/timing.cpp
+++ b/FSW/src/util/timing.cpp
@@ -128,8 +128,7 @@ void updatePayloadMode(float buffer[], int bufIdx){
         //       it honestly might be best to leave it as having to manually start
         //       a data window for testing
         
-        // execute commands  
-        commandHandling();
+
 
         // TODO: memory scrubbing  
 
@@ -219,9 +218,8 @@ void checkSweepChange(float buffer[], int bufIdx){
     float pdOld = smoothBuffer(buffer, wrapBufferIdx(bufIdx - ADCS_SWEEP_IDX_OFFSET));
 
     // change the sweep direction if the voltage crossed the threshold
-    //  if both expressions have the same logical value, it means that the
-    //  photodiode voltage was on the same side of the threshold for both measurements 
-    if ((pdNew < SUN_THRESH_VOLTAGE) != (pdOld < SUN_THRESH_VOLTAGE)){
+    //  requires optic to have recently dropped below the voltage threshold 
+    if ((pdNew < SUN_THRESH_VOLTAGE) && (pdOld > SUN_THRESH_VOLTAGE)){
         sweepDirectionChangeEvent.invoke();
     }
 }

--- a/FSW/src/util/timing.cpp
+++ b/FSW/src/util/timing.cpp
@@ -57,7 +57,7 @@ void ScienceMode::setPointingAtSun(bool newState){
 void ScienceMode::sweepChange(){
     // method to check if the ADCS system has permission to change sweep direction
     // and invoke the sweep change event if so
-    if (!sweepChangeLockout.isInvoked()){
+    if (!sweepChangeLockout.checkInvoked()){
         sweepChangeEvent.invoke();
         sweepChangeLockout.start();
     }


### PR DESCRIPTION
Ironed out syntax for including `TimedEvent` object inside `ScienceMode` class, there were some compile order struggles here. This means that I set the value of my `TimedEvent` object inside this class using a `setDuration()` call in a new `init()` function in `main.cpp`. This is because I want to define this time with a const macro, but I have to define that macro in `config.hpp`. This config file must be included after `timingClass.hpp` since config uses `ScienceMode` objects inside it. This creates a cyclical dependency between these two files if I want to instantiate a `TimedEvent` object using a macro inside the `ScienceMode` class. Therefore, I overloaded the constructor for `TimedEvent` to have a default duration of 1 second if no duration is specified at declaration. Then, in `init()` I change the duration to the proper number, defined by the constant macro in `config.hpp`. 

I also laid the groundwork for timestamping the photodiode files and addressed some feedback from the timing module PR, but that is pretty self explanatory. 