### PR TITLE
Bugfixes and more

### DIFF
--- a/FSW/main.cpp
+++ b/FSW/main.cpp
@@ -135,7 +135,7 @@ int main() {
         
 
         if (exitMainLoopEvent.checkInvoked()) {
-            clearResetCount();
+            prepareForRestart();
             Serial.print("Exiting main loop at iteration ");
             Serial.println(mainLoopIterations);
             break;

--- a/FSW/main.cpp
+++ b/FSW/main.cpp
@@ -107,6 +107,11 @@ int main() {
             handleHousekeeping();
         }  
 
+        // feed the dog
+        if (wdTimer.checkInvoked()) {
+            feedWD();
+        }
+
 
         /* - ONLY EXECTUTE DURING NORMAL OPERATION - */
         if (scienceMode.getMode() != SAFE_MODE) {

--- a/FSW/src/headers/commandHandling.hpp
+++ b/FSW/src/headers/commandHandling.hpp
@@ -51,7 +51,8 @@ namespace commandCode {
         SCRUB_FLASH,                   // start scrubbing the flash memory for errors
 
         // Fault Mitigation
-        CLEAR_ALL_PERSISTENT_DATA,     // clears all persistent data stored in EEPROM
+        WIPE_EEPROM,                   // completely wipes the EEPROM and then resets persistent data
+        RESET_PERSISTENT_DATA,         // resets all persistent data to default values
         ACT_ON_FAULTS_T,               // sets fault action flag so that corrective action is taken
         ACT_ON_FAULTS_F,               // sets fault action flag so that corrective action is not taken
 

--- a/FSW/src/headers/commandHandling.hpp
+++ b/FSW/src/headers/commandHandling.hpp
@@ -39,6 +39,8 @@ namespace commandCode {
         HEATER_OFF,                     // turn heater off, does not override housekeeping heater control
         FORCE_HEATER_ON_T,              // force the heater on, overrrides houskeeping heater control
         FORCE_HEATER_ON_F,              // stop forcing the heater on, giving control back to housekeeping
+        STREAM_TEMPERATURE_T,           // start streaming temperature measurements
+        STREAM_TEMPERATURE_F,           // stop streaming temperature measurements
         CALIBRATE_OPTICS_THERM,         // take new voltage measurement at known temp for optics thermistor
 
         // Command Handling
@@ -57,6 +59,8 @@ namespace commandCode {
         // Fault Mitigation
         WIPE_EEPROM,                   // completely wipes the EEPROM and then resets persistent data
         RESET_PERSISTENT_DATA,         // resets all persistent data to default values
+        SUPPRESS_FAULTS_T,             // stops new faults from being logged
+        SUPPRESS_FAULTS_F,             // allows new faults to be logged
         ACT_ON_FAULTS_T,               // sets fault action flag so that corrective action is taken
         ACT_ON_FAULTS_F,               // sets fault action flag so that corrective action is not taken
 

--- a/FSW/src/headers/commandHandling.hpp
+++ b/FSW/src/headers/commandHandling.hpp
@@ -22,12 +22,16 @@ namespace commandCode {
     // command codes are wrapped in a namespace so they are not global
     enum Code { // all possible commands
         // commands are 1 indexed so that the default initializer can be used for the command queue
-        // Mode change
+        // Mode Change
         ENTER_SAFE_MODE = 1,            // enter safemode state
         ENTER_STANDBY_MODE,             // enter standby state
         ENTER_SUNSET_MODE,              // enter sunset data collection mode
         ENTER_PRE_SUNRISE_MODE,         // enter watch-for-sunset mode
         ENTER_SUNRISE_MODE,             // enter sunrise data collection mode
+
+        // Data Collection
+        STREAM_PHOTO_DATA_T,            // start streaming photodiode data
+        STREAM_PHOTO_DATA_F,            // stop streaming photodiode data
         
         // Housekeeping
         DISABLE_WD_RESET,               // disable watchdog reset signal, forcing a restart

--- a/FSW/src/headers/config.hpp
+++ b/FSW/src/headers/config.hpp
@@ -6,8 +6,9 @@
  *  sampling rates, etc) that we will want to be able to change
  *  from a single location and include in multiple modules
  * 
- *  declare all objects as extern to avoid the error 
- *      "multiple definitions of <object>" during compilation
+ *  Delcare all non-constant object as 'extern' and define them in externalDefinitions.cpp
+ *  to create a single instance shared across all files. 
+ *  Objects not declared as `extern` will not be linked between files. 
  */
 
 //C++ libraries

--- a/FSW/src/headers/config.hpp
+++ b/FSW/src/headers/config.hpp
@@ -72,8 +72,8 @@ const float ADC_MIN_VOLTAGE = 0.0;  // Volts, lower end of ADC voltage range
 const float ADC_VOLTAGE_RES = (ADC_MAX_VOLTAGE - ADC_MIN_VOLTAGE) / ADC_BINS; // volts per ADC bin
 
 // Continuous data streaming
-extern volatile bool STREAM_PHOTO_DATA; // whether to print photodiode samples in real time.
-const bool STREAM_PHOTO_DATA_INIT = false;
+extern volatile bool STREAM_PHOTO_DATA;
+const bool STREAM_PHOTO_DATA_INIT = false; // whether to print photodiode samples in real time.
 
 // TODO: Update this with size of actual timestamp once it is known
 const int TIMESTAMP_SIZE = sizeof(unsigned long);   // bytes needed to store timestamp
@@ -102,9 +102,12 @@ const int COMMAND_QUEUE_SIZE = 100;     // maximum number of commands the comman
 
 
 /* - - - - - - Fault Mitigation Module - - - - - - */
+extern volatile bool SUPPRESS_FAULTS;
+const bool SUPPRESS_FAULTS_INIT = false;  // whether or not to log new fault occurrences.
+
 // Corrective action
-extern volatile bool ACT_ON_NEW_FAULTS; // whether to attempt corrective action when faults are detected
-const bool ACT_ON_NEW_FAULTS_INIT = true;
+extern volatile bool ACT_ON_NEW_FAULTS; 
+const bool ACT_ON_NEW_FAULTS_INIT = true; // whether to attempt corrective action when faults are detected
 
 // EEPROM
 const int PERSIST_DATA_ADDR = 0; // first address of persistent system data in EEPROM
@@ -114,14 +117,18 @@ const uint8_t EXPECTING_RESTART_FLAG = 0xaa; // 10101010, value of flag indicati
 // watchdog
 const int WD_RESET_INTERVAL_MSEC = 100;     // milliseconds, watchdog feeding interval
 const int WD_PULSE_DUR_MICROSEC = 10;       // microseconds, watchdog reset signal duration
-
+extern RecurringEvent wdTimer;
 
 /* - - - - - - Housekeeping Module - - - - - - */
 const int HK_SAMPLES_TO_KEEP = 5000;   // number of previous housekeeping samples to keep
 
 // Heater control override
-extern volatile bool FORCE_HEATER_ON;   // if true, heater will always be on regardless of temperature
-const bool FORCE_HEATER_ON_INIT = false;
+extern volatile bool FORCE_HEATER_ON;
+const bool FORCE_HEATER_ON_INIT = false; // if true, heater will always be on regardless of temperature
+
+// Real time temperature data streaming
+extern volatile bool STREAM_TEMPERATURE;
+const bool STREAM_TEMPERATURE_INIT = false; // if true, temperature data will be printed over serial in real time
 
 // Heater cutoff temperatures
 const float HEATER_TEMP_LOW = -20;   // celsius, heater will turn on at or below this temp

--- a/FSW/src/headers/config.hpp
+++ b/FSW/src/headers/config.hpp
@@ -6,7 +6,7 @@
  *  sampling rates, etc) that we will want to be able to change
  *  from a single location and include in multiple modules
  * 
- *  declare all objects as static to avoid the error 
+ *  declare all objects as extern to avoid the error 
  *      "multiple definitions of <object>" during compilation
  */
 
@@ -58,7 +58,7 @@ const bool ADCS_READY_FOR_SCIENCE = true;     // flag on whether or not attitude
  * = = = = = = = = = = = = = = = = = = = = = */
 
 /* - - - - - - Main - - - - - - */
-static Event exitMainLoopEvent; // event to trigger main loop exit
+extern Event exitMainLoopEvent; // event to trigger main loop exit
 
 
 /* - - - - - - Data Collection Module - - - - - - */
@@ -69,6 +69,10 @@ const float ADC_BINS = 65536;       // bins, number of bins in ADC (2^16)
 const float ADC_MAX_VOLTAGE = 3.3;  // Volts, upper end of ADC voltage range
 const float ADC_MIN_VOLTAGE = 0.0;  // Volts, lower end of ADC voltage range
 const float ADC_VOLTAGE_RES = (ADC_MAX_VOLTAGE - ADC_MIN_VOLTAGE) / ADC_BINS; // volts per ADC bin
+
+// Continuous data streaming
+extern volatile bool STREAM_PHOTO_DATA; // whether to print photodiode samples in real time.
+const bool STREAM_PHOTO_DATA_INIT = true;
 
 // TODO: Update this with size of actual timestamp once it is known
 const int TIMESTAMP_SIZE = sizeof(unsigned long);   // bytes needed to store timestamp
@@ -84,12 +88,12 @@ const int WINDOW_LENGTH_MSEC = WINDOW_LENGTH_SEC * 1000; // milliseconds, length
 const int SWEEP_TIMEOUT_MSEC = 1000; // milliseconds, time for ADCS to sweep optic across the sun
 
 // Events
-static RecurringEvent dataProcessEvent(SAMPLE_PERIOD_MSEC); // assuming that duration arg is ms
-static Event saveBufferEvent;
-static TimedEvent sunriseTimerEvent(WINDOW_LENGTH_MSEC);
-static TimedEvent sweepTimeoutEvent(SWEEP_TIMEOUT_MSEC);
-static AsyncEvent downlinkEvent(MAXFILES);
-static AsyncEvent scrubEvent(MAXFILES);
+extern RecurringEvent dataProcessEvent; // assuming that duration arg is ms
+extern Event saveBufferEvent;
+extern TimedEvent sunriseTimerEvent;
+extern TimedEvent sweepTimeoutEvent;
+extern AsyncEvent downlinkEvent;
+extern AsyncEvent scrubEvent;
 
 
 /* - - - - - - Command Handling Module - - - - - - */
@@ -97,8 +101,13 @@ const int COMMAND_QUEUE_SIZE = 100;     // maximum number of commands the comman
 
 
 /* - - - - - - Fault Mitigation Module - - - - - - */
-static volatile bool ACT_ON_NEW_FAULTS = true;
+// Corrective action
+extern volatile bool ACT_ON_NEW_FAULTS; // whether to attempt corrective action when faults are detected
+const bool ACT_ON_NEW_FAULTS_INIT = true;
+
+// EEPROM
 const int PERSIST_DATA_ADDR = 0; // first address of persistent system data in EEPROM
+const int EEPROM_SIZE = 1080; // size of EEPROM in bytes
 const uint8_t EXPECTING_RESTART_FLAG = 0xaa; // 10101010, value of flag indicating that the last restart was expected.
 
 // watchdog
@@ -109,15 +118,19 @@ const int WD_PULSE_DUR_MICROSEC = 10;       // microseconds, watchdog reset sign
 /* - - - - - - Housekeeping Module - - - - - - */
 const int HK_SAMPLES_TO_KEEP = 5000;   // number of previous housekeeping samples to keep
 
-// heater cutoff temperatures
-static volatile bool FORCE_HEATER_ON = false;   // if true, heater will always be on regardless of temperature
+// Heater control override
+extern volatile bool FORCE_HEATER_ON;   // if true, heater will always be on regardless of temperature
+const bool FORCE_HEATER_ON_INIT = false;
+
+// Heater cutoff temperatures
 const float HEATER_TEMP_LOW = -20;   // celsius, heater will turn on at or below this temp
 const float HEATER_TEMP_HIGH = 20;   // celsius, heater will turn off at or above this temp
 
 // optics thermistor calibration
-const float OPTICS_THERM_CAL_TEMP = 30;            // celsius, known temperature of optics baseline
-static volatile float OPTICS_THERM_CAL_VOLTAGE = 1.777F;    // volts, thermistor voltage at baseline temp
-const float OPTICS_THERM_GAIN = -0.0109;           // volts/deg celsius, V/T relationship for optics thermistor
+const float OPTICS_THERM_CAL_TEMP = 30;             // celsius, known temperature of optics baseline
+const float OPTICS_THERM_GAIN = -0.0109;            // volts/deg celsius, V/T relationship for optics thermistor
+extern volatile float OPTICS_THERM_CAL_VOLTAGE;    
+const float OPTICS_THERM_CAL_VOLTAGE_INIT = 1.777F; // volts, thermistor voltage at baseline temp
 
 // safe temperature range
 const float OPTICS_TEMP_MIN_SAFE = -35; // celsius, minimum safe photodiode temp
@@ -133,7 +146,7 @@ const float PG_VOLTAGE_MIN_EXPECTED = 3.2;  // volts, minimum expected reading f
 const int HK_SAMPLE_PERIOD_MSEC = 1000;    // milliseconds, interval between housekeeping updates
 
 // Events
-static RecurringEvent housekeepingTimer(HK_SAMPLE_PERIOD_MSEC);
+extern RecurringEvent housekeepingTimer;
 
 
 /* - - - - - - Timing Module - - - - - - */
@@ -143,6 +156,6 @@ const int ADCS_SWEEP_IDX_OFFSET = SMOOTH_IDX_COUNT; // number of indices to trav
 const int ADCS_SWEEP_CHANGE_DURATION = 2 * SMOOTH_IDX_COUNT * SAMPLE_PERIOD_MSEC; // millisec, duration to prevent ADCS sweep direction change
 
 // timing science mode object declaration
-static ScienceMode scienceMode;
+extern ScienceMode scienceMode;
 
 #endif

--- a/FSW/src/headers/config.hpp
+++ b/FSW/src/headers/config.hpp
@@ -6,7 +6,7 @@
  *  sampling rates, etc) that we will want to be able to change
  *  from a single location and include in multiple modules
  * 
- *  Delcare all non-constant object as 'extern' and define them in externalDefinitions.cpp
+ *  Delcare all non-constant objects as 'extern' and define them in externalDefinitions.cpp
  *  to create a single instance shared across all files. 
  *  Objects not declared as `extern` will not be linked between files. 
  */

--- a/FSW/src/headers/config.hpp
+++ b/FSW/src/headers/config.hpp
@@ -6,7 +6,7 @@
  *  sampling rates, etc) that we will want to be able to change
  *  from a single location and include in multiple modules
  * 
- *  Delcare all non-constant objects as 'extern' and define them in externalDefinitions.cpp
+ *  Declare all non-constant objects as 'extern' and define them in externalDefinitions.cpp
  *  to create a single instance shared across all files. 
  *  Objects not declared as `extern` will not be linked between files. 
  */

--- a/FSW/src/headers/config.hpp
+++ b/FSW/src/headers/config.hpp
@@ -72,7 +72,7 @@ const float ADC_VOLTAGE_RES = (ADC_MAX_VOLTAGE - ADC_MIN_VOLTAGE) / ADC_BINS; //
 
 // Continuous data streaming
 extern volatile bool STREAM_PHOTO_DATA; // whether to print photodiode samples in real time.
-const bool STREAM_PHOTO_DATA_INIT = true;
+const bool STREAM_PHOTO_DATA_INIT = false;
 
 // TODO: Update this with size of actual timestamp once it is known
 const int TIMESTAMP_SIZE = sizeof(unsigned long);   // bytes needed to store timestamp

--- a/FSW/src/headers/faultManager.hpp
+++ b/FSW/src/headers/faultManager.hpp
@@ -40,7 +40,7 @@ struct FaultReport {
     uint8_t pendingAction = 0; 
     uint16_t startNum = 1;
     uint32_t timestamp = 0;
-    static const int MEMSIZE = 64;
+    static const int MEMSIZE = 8;
 };
 
 struct PayloadData {
@@ -49,7 +49,7 @@ struct PayloadData {
         uint16_t consecutiveBadRestarts = 0;
         uint32_t eepromWriteCount = 0;
         uint8_t recoveredMode = 0;
-        static const size_t MEMSIZE = 72;
+        static const size_t MEMSIZE = 10;
 };
 
 extern PayloadData payloadData;

--- a/FSW/src/headers/faultManager.hpp
+++ b/FSW/src/headers/faultManager.hpp
@@ -26,15 +26,17 @@ namespace faultCode {
         OPTICS_TOO_COLD,
 
         // Power
-        DREG_OUT_OF_RANGE,
+        DREG_OUT_OF_RANGE,      // Digital regulator voltage is out of normal range
         
+        // Bad News
+        EEPROM_CORRUPTED,       // EEPROM data is corrupted beyond rescue
         ERR_CODE
     };
     const int COUNT = ERR_CODE + 1;
 };
 
 struct FaultReport {
-    uint8_t occurences = 0;
+    uint8_t occurrences = 0;
     uint8_t pendingAction = 0; 
     uint16_t startNum = 1;
     uint32_t timestamp = 0;
@@ -50,17 +52,19 @@ struct PayloadData {
         static const size_t MEMSIZE = 72;
 };
 
-static PayloadData payloadData;
+extern PayloadData payloadData;
 
 /* - - - - - - Function Declarations - - - - - - */
 void logFault(int code);
 void feedWD();
 void handleFaults();
 
-void clearAllPersistentData();
+void wipeEEPROM();
+void resetPersistentData();
+
 void recordNewStart();
 void prepareForRestart();
-void saveEEPROM();
+int saveEEPROM();
 void loadEEPROM();
 void resetFaultCounts();
 

--- a/FSW/src/util/commandHandling.cpp
+++ b/FSW/src/util/commandHandling.cpp
@@ -211,17 +211,19 @@ void executeCommand(int command) {
         // Data Collection
         case commandCode::STREAM_PHOTO_DATA_T:
             STREAM_PHOTO_DATA = true;
-            Serial.println("Command Executed - Transmitting photdiode voltages in real time.");
+            Serial.println("Command Executed - Transmitting photodiode voltages in real time.");
+            Serial.println("time (ms) | photodiode voltage (V)");
             break;
 
         case commandCode::STREAM_PHOTO_DATA_F:
             STREAM_PHOTO_DATA = false;
-            Serial.println("Command Executed - Stopped photodiode data streaming.");
+            Serial.println("Command Executed - Stopped streaming photodiode data");
             break;
 
         // Housekeeping
         case commandCode::DISABLE_WD_RESET: 
-            // TODO: change wd timer duration by calling setDuration()
+            wdTimer.setDuration(0xFFFFFFFF); // that should do it.
+            Serial.println("Command Executed - Watchdog will not be fed. Restart imminent!");
             break;
         
         case commandCode::HEATER_ON: 
@@ -242,6 +244,17 @@ void executeCommand(int command) {
         case commandCode::FORCE_HEATER_ON_F:
             FORCE_HEATER_ON = false;
             Serial.println("Command Executed - Automatic heater control enabled.");
+            break;
+
+        case commandCode::STREAM_TEMPERATURE_T:
+            STREAM_TEMPERATURE = true;
+            Serial.println("Command Executed - Transmitting temperature data in real time.");
+            Serial.println("time (ms) | optics temp (C) | analog temp (C) | digital temp (C)");
+            break;
+
+        case commandCode::STREAM_TEMPERATURE_F:
+            STREAM_TEMPERATURE = false;
+            Serial.println("Command Executed - Stopped streaming temperature data.");
             break;
 
         case commandCode::CALIBRATE_OPTICS_THERM:
@@ -299,7 +312,16 @@ void executeCommand(int command) {
             resetPersistentData();
             Serial.println("Command Executed - Persistent data cleared");
             break;
+        
+        case commandCode::SUPPRESS_FAULTS_T:
+            SUPPRESS_FAULTS = true;
+            Serial.println("Command Executed - New faults are now suppressed.");
+            break;
 
+        case commandCode::SUPPRESS_FAULTS_F:
+            SUPPRESS_FAULTS = false;
+            Serial.println("Command Executed - New faults can now be logged.");
+            break;
 
         case commandCode::ACT_ON_FAULTS_T:
             ACT_ON_NEW_FAULTS = true;

--- a/FSW/src/util/commandHandling.cpp
+++ b/FSW/src/util/commandHandling.cpp
@@ -279,10 +279,16 @@ void executeCommand(int command) {
             break;
 
         // Fault Mitigation
-        case commandCode::CLEAR_ALL_PERSISTENT_DATA:
-            clearAllPersistentData();
+        case commandCode::WIPE_EEPROM:
+            wipeEEPROM();
+            Serial.println("Command Executed - Wipe EEPROM");
+            break;
+
+        case commandCode::RESET_PERSISTENT_DATA:
+            resetPersistentData();
             Serial.println("Command Executed - Persistent data cleared");
             break;
+
 
         case commandCode::ACT_ON_FAULTS_T:
             ACT_ON_NEW_FAULTS = true;

--- a/FSW/src/util/commandHandling.cpp
+++ b/FSW/src/util/commandHandling.cpp
@@ -207,7 +207,18 @@ void executeCommand(int command) {
             scienceMode.setMode(SUNRISE_MODE);
             Serial.println("Command Executed - Entering Sunrise Mode.");
             break;
-        
+
+        // Data Collection
+        case commandCode::STREAM_PHOTO_DATA_T:
+            STREAM_PHOTO_DATA = true;
+            Serial.println("Command Executed - Transmitting photdiode voltages in real time.");
+            break;
+
+        case commandCode::STREAM_PHOTO_DATA_F:
+            STREAM_PHOTO_DATA = false;
+            Serial.println("Command Executed - Stopped photodiode data streaming.");
+            break;
+
         // Housekeeping
         case commandCode::DISABLE_WD_RESET: 
             // TODO: change wd timer duration by calling setDuration()

--- a/FSW/src/util/dataCollection.cpp
+++ b/FSW/src/util/dataCollection.cpp
@@ -70,6 +70,12 @@ float dataProcessing() {
      *      lead to more work for future teams trying to retrofit our format
      */
 
+    // print the voltage value (for testing)
+    if (STREAM_PHOTO_DATA) {
+        float voltage = photodiode16 * ADC_VOLTAGE_RES;
+        Serial.println(voltage);
+    }
+
     // return the bin number
     return photodiode16;
 }

--- a/FSW/src/util/dataCollection.cpp
+++ b/FSW/src/util/dataCollection.cpp
@@ -73,6 +73,9 @@ float dataProcessing() {
     // print the voltage value (for testing)
     if (STREAM_PHOTO_DATA) {
         float voltage = photodiode16 * ADC_VOLTAGE_RES;
+        Serial.print("PHOTO, ");
+        Serial.print(millis());
+        Serial.print(", ");
         Serial.println(voltage);
     }
 

--- a/FSW/src/util/externalConfig.cpp
+++ b/FSW/src/util/externalConfig.cpp
@@ -1,0 +1,31 @@
+/* externalConfig.cpp DEFINES all global objects declared with the 'extern' keyword in config.hpp
+    The compiler will point all files to these definitions, so that only one instance of each object exists globally.
+    DO NOT DEFINE THESE OBJECTS ANYWHERE ELSE!!!
+*/
+
+// Config Header
+#include "../headers/config.hpp"
+
+/* GLOBAL DEFINITIONS */
+// Main
+Event exitMainLoopEvent = Event();
+
+// Data Collection
+volatile bool STREAM_PHOTO_DATA = STREAM_PHOTO_DATA_INIT;
+RecurringEvent dataProcessEvent = RecurringEvent(SAMPLE_PERIOD_MSEC);
+Event saveBufferEvent = Event();
+TimedEvent sunriseTimerEvent = TimedEvent(WINDOW_LENGTH_MSEC);
+TimedEvent sweepTimeoutEvent = TimedEvent(SWEEP_TIMEOUT_MSEC);
+AsyncEvent downlinkEvent = AsyncEvent(MAXFILES);
+AsyncEvent scrubEvent = AsyncEvent(MAXFILES);
+
+// Fault Mitigation
+volatile bool ACT_ON_NEW_FAULTS = ACT_ON_NEW_FAULTS_INIT;
+
+// Housekeeping
+volatile bool FORCE_HEATER_ON = FORCE_HEATER_ON_INIT;
+volatile float OPTICS_THERM_CAL_VOLTAGE = OPTICS_THERM_CAL_VOLTAGE_INIT;
+RecurringEvent housekeepingTimer = RecurringEvent(HK_SAMPLE_PERIOD_MSEC);
+
+// Timing
+ScienceMode scienceMode = ScienceMode();

--- a/FSW/src/util/externalDefinitions.cpp
+++ b/FSW/src/util/externalDefinitions.cpp
@@ -1,5 +1,5 @@
-/* externalConfig.cpp DEFINES all global objects declared with the 'extern' keyword in config.hpp
-    The compiler will point all files to these definitions, so that only one instance of each object exists globally.
+/* externalDefinitions.cpp DEFINES all global objects declared with the 'extern' keyword in config.hpp
+    The compiler will point all files to these definitions so that only one instance of each object exists globally.
     DO NOT DEFINE THESE OBJECTS ANYWHERE ELSE!!!
 */
 

--- a/FSW/src/util/externalDefinitions.cpp
+++ b/FSW/src/util/externalDefinitions.cpp
@@ -20,10 +20,13 @@ AsyncEvent downlinkEvent = AsyncEvent(MAXFILES);
 AsyncEvent scrubEvent = AsyncEvent(MAXFILES);
 
 // Fault Mitigation
+volatile bool SUPPRESS_FAULTS = SUPPRESS_FAULTS_INIT;
 volatile bool ACT_ON_NEW_FAULTS = ACT_ON_NEW_FAULTS_INIT;
+RecurringEvent wdTimer = RecurringEvent(WD_RESET_INTERVAL_MSEC);
 
 // Housekeeping
 volatile bool FORCE_HEATER_ON = FORCE_HEATER_ON_INIT;
+volatile bool STREAM_TEMPERATURE = STREAM_TEMPERATURE_INIT;
 volatile float OPTICS_THERM_CAL_VOLTAGE = OPTICS_THERM_CAL_VOLTAGE_INIT;
 RecurringEvent housekeepingTimer = RecurringEvent(HK_SAMPLE_PERIOD_MSEC);
 

--- a/FSW/src/util/faultManager.cpp
+++ b/FSW/src/util/faultManager.cpp
@@ -47,6 +47,7 @@ static bool detectedFault = false;
  *  None
  */
 void logFault(int code) {
+    if (SUPPRESS_FAULTS) { return; }
     detectedFault = true;
 
     // check if fault is valid

--- a/FSW/src/util/hammingBlock.cpp
+++ b/FSW/src/util/hammingBlock.cpp
@@ -126,10 +126,7 @@ ErrorReport HammingBlock::scanBlock() {
     }
     // calculate block parity
     bool blockParity = !!(totalSetBits % 2);
-    Serial.println(totalSetBits);
-    Serial.println(checkBit(m_block, 0));
-    Serial.println(blockParity);
-    Serial.println(checkBit(m_block, 0) == blockParity);
+
     // determine error type
     if (checkBit(m_block, 0) == blockParity) {
         if (indexParity == 0) {

--- a/FSW/src/util/housekeeping.cpp
+++ b/FSW/src/util/housekeeping.cpp
@@ -115,6 +115,17 @@ void sampleHousekeepingData() {
     if (latestHkSample.digitalRegPG > PG_VOLTAGE_MAX_EXPECTED || latestHkSample.digitalRegPG < PG_VOLTAGE_MIN_EXPECTED) { 
         logFault(faultCode::DREG_OUT_OF_RANGE); } // digital regulator PG signal too low
 
+    // Print temperature data
+    if (STREAM_TEMPERATURE) {
+        Serial.print("TEMP, ");
+        Serial.print(millis());
+        Serial.print(", ");
+        Serial.print(latestHkSample.opticsTemp);
+        Serial.print(", ");
+        Serial.print(latestHkSample.analogTemp);
+        Serial.print(", ");
+        Serial.println(latestHkSample.digitalTemp);
+    }
 }
 
 /* - - - - - - voltageToBoardTemp - - - - - - *


### PR DESCRIPTION
Fixed the issue where static objects in config were not referencing properly. Declaring them as static didn't do what we thought, and every file ended up with their own private copies of all variables in `config.hpp`, static or not. 
Now all non-constant global variables are declared as `extern` instead of `static`, which basically tells to compiler "Trust me, this variable is defined somewhere, go look for it." Fun fact: this is how function calls in multiple files can reference the same function definition, the compiler actually interprets `void foo()` as `extern void foo()`.

The actual definitions for each non-constant variable are in a new file, `externalDefinitions.cpp`. The compiler will point every file to the the instances defined here. I added new constants to `config.hpp` for the initialization values of `bool` and `float` variables, so we can still configure everything from `config.hpp`, and `externalDefnitions.cpp` can chill behind the scenes.

Some of the suggested changes to the fault mitigation PR are also mixed in here, since I did it all at once. In addition to the suggested changes, I fixed a bunch of bugs and added a new command to completely wipe the EEPROM. For safety, the wipe EEPROM command needs to be sent twice in a row before it will work, since it should only ever be used during development, or if the EEPROM becomes corrupted.

Finally, I added a flag `STREAM_PHOTO_DATA`, and the corresponding commands to set it. If true, `dataProcessing()` will print the voltage value of each incoming photodiode sample in real time. 
